### PR TITLE
issue #4: backslash on windows broke RegExp

### DIFF
--- a/lib/parse-helpers.js
+++ b/lib/parse-helpers.js
@@ -139,6 +139,7 @@ module.exports = (function() {
 
 	function processCssFile(file, css) {
 		Object.keys(css).forEach(function(imageURL) {
+			imageURL.replace(/[\\]/, '\/');
 			file.data = file.data.replace(new RegExp('^.*' + imageURL + '.*$', 'gm'), css[imageURL]);
 		});
 		return file;


### PR DESCRIPTION
Doing processCssFile() parsed files use background-url which are builded with forward slash ("path/to/img"), other way in Windows these paths are constructed using backslashes. This cause false regexp and CSS properties are not rewrited in result files.
